### PR TITLE
Fix array slicing using a float as index

### DIFF
--- a/eulerian_magnification/base.py
+++ b/eulerian_magnification/base.py
@@ -62,8 +62,8 @@ def show_frequencies(vid_data, fps, bounds=None):
     freqs = freqs[idx]
     fft = fft[idx]
 
-    freqs = freqs[len(freqs) / 2 + 1:]
-    fft = fft[len(fft) / 2 + 1:]
+    freqs = freqs[len(freqs) // 2 + 1:]
+    fft = fft[len(fft) // 2 + 1:]
     pyplot.plot(freqs, abs(fft))
 
     pyplot.show()


### PR DESCRIPTION
Fixes the following TypeError: "slice indices must be integers or None or have an __index__ method".