### PR TITLE
pip3.6 -> pip3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM jjanzic/docker-python3-opencv:contrib
 WORKDIR /code
 COPY requirements.txt setup.py /code/
 RUN mkdir eulerian_magnification
-RUN pip3.6 install -r requirements.txt
+RUN pip3 install -r requirements.txt
 COPY . /code/
-RUN pip3.6 install -r requirements.txt
+RUN pip3 install -r requirements.txt


### PR DESCRIPTION
Using `pip3.6` gives this error while building the image:

```
/bin/sh: 1: pip3.6: not found
```